### PR TITLE
feat: install script checks python version

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2,8 +2,27 @@
 
 set -e
 
-python3 -m venv _term_env_
+script=$(basename "$0")
+version=$(python3 -V 2>&1 | grep -Po '(?<=Python )(.+)')
+if [[ -z "$version" ]]
+then
+    echo "No Python!"
+fi
+
+parsedVersion=$(echo "${version//./}")
+setVersion=$1
+if [[ $parsedVersion -lt "3100" && $# -eq 0 ]]
+then
+    echo "Invalid python3 version, either update python3 or include the correct executable when running this script"
+    echo "For example ./$script python3.10"
+    exit 1
+elif [[ $parsedVersion -eq "3100" || $parsedVersion -gt "3100" && $# -eq 0 ]]
+then
+    setVersion="python3"
+fi
+
+$setVersion -m venv _term_env_
 source _term_env_/bin/activate
-python3 -m pip install --upgrade pip
-python3 -m pip install -r requirements.txt
-python3 main.py
+$setVersion -m pip install --upgrade pip
+$setVersion -m pip install -r requirements.txt
+$setVersion main.py


### PR DESCRIPTION
If python version is not 3.10 or newer user is asked to either update python or pass the correct python command as an argument when executing the script